### PR TITLE
mallocMC: Definitions, Component and Library Support

### DIFF
--- a/FindmallocMC.cmake
+++ b/FindmallocMC.cmake
@@ -11,7 +11,9 @@
 #   )
 #
 # To provide a hint to this module where to find the mallocMC installation,
-# set the MALLOCMC_ROOT environment variable.
+# set the MALLOCMC_ROOT environment variable. You can also set the
+# MALLOCMC_ROOT CMake variable, which will take precedence over the environment
+# variable.
 #
 # This module requires CUDA and Boost. When calling it, make sure to call
 # find_package(CUDA) and find_package(Boost) first.

--- a/FindmallocMC.cmake
+++ b/FindmallocMC.cmake
@@ -65,7 +65,7 @@ find_package(Boost 1.48.0 REQUIRED)
 #
 find_path(mallocMC_ROOT_DIR
     NAMES include/mallocMC/mallocMC.hpp
-    PATHS "${CMAKE_CURRENT_SOURCE_DIR}/../../thirdParty/mallocMC/" ENV MALLOCMC_ROOT
+    PATHS ENV MALLOCMC_ROOT
     PATH_SUFFIXES "src"
     DOC "mallocMC ROOT location"
     )

--- a/FindmallocMC.cmake
+++ b/FindmallocMC.cmake
@@ -65,7 +65,7 @@ find_package(Boost 1.48.0 REQUIRED)
 #
 find_path(mallocMC_ROOT_DIR
     NAMES include/mallocMC/mallocMC.hpp
-    PATHS ENV MALLOCMC_ROOT
+    PATHS ${MALLOCMC_ROOT} ENV MALLOCMC_ROOT
     PATH_SUFFIXES "src"
     DOC "mallocMC ROOT location"
     )


### PR DESCRIPTION
- REQUIRED and QUIET work as intended
- halloc is available as a COMPONENT (beta)
- see #3 for the full writeup

To circumvent the path problem, it could be used in a `CMakeLists.txt` like this:

``` cmake
find_package(mallocMC 2.1.0 QUIET)

if(NOT mallocMC_FOUND)
  message(STATUS "Using mallocMC from thirdParty/ directory")
  set(MALLOCMC_ROOT "../../thirdParty/mallocMC")
  find_package(mallocMC 2.1.0 REQUIRED)
endif(NOT mallocMC_FOUND)

include_directories(SYSTEM ${mallocMC_INCLUDE_DIRS})
add_definitions(${mallocMC_DEFINITIONS})
# append ${mallocMC_LIBRARIES} to your target libraries, e.g.,
# set(LIBS ${LIBS} ${mallocMC_LIBRARIES})
#   or
# list(APPEND LIBS ${mallocMC_LIBRARIES})
```
