### PR TITLE
Fix: Undefined List for FindmallocMC

### DIFF
--- a/FindmallocMC.cmake
+++ b/FindmallocMC.cmake
@@ -75,6 +75,7 @@ find_path(mallocMC_ROOT_DIR
     DOC "mallocMC ROOT location"
     )
 
+set(mallocMC_REQUIRED_VARS_LIST mallocMC_ROOT_DIR mallocMC_INCLUDE_DIRS)
 
 if(mallocMC_ROOT_DIR)
 
@@ -95,7 +96,6 @@ if(mallocMC_ROOT_DIR)
 
     # mallocMC variables ########################################################
     #
-    set(mallocMC_REQUIRED_VARS_LIST mallocMC_ROOT_DIR mallocMC_INCLUDE_DIRS)
     set(mallocMC_VERSION "${mallocMC_VERSION_MAJOR}.${mallocMC_VERSION_MINOR}.${mallocMC_VERSION_PATCH}")
     set(mallocMC_INCLUDE_DIRS ${mallocMC_ROOT_DIR}/include)
 


### PR DESCRIPTION
@slizzered In case the library was not found, the list of required (then not set variables) should still be available.

Fixes error:

```
CMake Error at thirdParty/cmake-modules/FindmallocMC.cmake:154 (list):
  list sub-command REMOVE_DUPLICATES requires list to be present.
```

introduced by #6 (this is the regression to our regression ;) ).
