### PR TITLE
ADIOS, PNGwriter: _FOUND Var

### DIFF
--- a/FindADIOS.cmake
+++ b/FindADIOS.cmake
@@ -58,7 +58,7 @@
 # Required cmake version
 ################################################################################
 
-cmake_minimum_required(VERSION 2.8.5)
+cmake_minimum_required(VERSION 2.8.11)
 
 
 ################################################################################
@@ -194,6 +194,7 @@ endif()
 # handles the REQUIRED, QUIET and version-related arguments for find_package
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(ADIOS
+    FOUND_VAR ADIOS_FOUND
     REQUIRED_VARS ADIOS_LIBRARIES ADIOS_INCLUDE_DIRS
     VERSION_VAR ADIOS_VERSION
 )

--- a/FindPNGwriter.cmake
+++ b/FindPNGwriter.cmake
@@ -55,7 +55,7 @@
 # Required cmake version
 ###############################################################################
 
-cmake_minimum_required(VERSION 2.8.5)
+cmake_minimum_required(VERSION 2.8.11)
 
 
 ###############################################################################
@@ -190,6 +190,7 @@ endif(NOT PNGwriter_FOUND)
 # handles the REQUIRED, QUIET and version-related arguments for find_package
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(PNGwriter
+    FOUND_VAR PNGwriter_FOUND
     REQUIRED_VARS PNGwriter_LIBRARIES PNGwriter_INCLUDE_DIRS
     VERSION_VAR PNGwriter_VERSION
 )


### PR DESCRIPTION
Same as #13: `_FOUND` was not set to false on VERSION mismatch.
