### PR TITLE
Doc: FindADIOS.cmake Typos

### DIFF
--- a/FindADIOS.cmake
+++ b/FindADIOS.cmake
@@ -8,7 +8,7 @@
 #                           #   component is not found
 #     [QUIET]               # ...
 #     [COMPONENTS <...>]    # Compiled in components: fortran, readonly,
-#                           # sequential (all are case insentative)
+#                           # sequential (all are case-insensitive)
 #   )
 #
 # Module that finds the includes and libraries for a working ADIOS install.
@@ -54,7 +54,7 @@
 #   target_link_libraries(foo ${ADIOS_LIBRARIES})
 # endif()
 ###############################################################################
-#Copyright (c) 2014, Axel Huebl and Felix Schmitt from http://picongpu.hzdr.de
+#Copyright (c) 2014-2019, Axel Huebl and Felix Schmitt from http://picongpu.hzdr.de
 #All rights reserved.
 
 #Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Update Copyright years and fix typo in "case-insensitive".

Seen during review of https://github.com/ComputationalRadiationPhysics/picongpu/pull/3116

Ref.: https://github.com/openPMD/openPMD-api/commit/ed837939ac08ea3901194509f1dccbaacc5f350c